### PR TITLE
Filling in issue template names & agenda items

### DIFF
--- a/.github/ISSUE_TEMPLATE/lect.md
+++ b/.github/ISSUE_TEMPLATE/lect.md
@@ -13,11 +13,10 @@ assignees: ''
 
 **Attendance**
 
-- [ ] team member1
-- [ ] team member2
-- [ ] team member3
-- [ ] team member4
-- [ ] team member5
+- [ ] Emily Perica
+- [ ] Ian Algenio
+- [ ] Jackson Lippert
+- [ ] Mark Kogan
 
 **Questions to Ask**
 

--- a/.github/ISSUE_TEMPLATE/sup_meet.md
+++ b/.github/ISSUE_TEMPLATE/sup_meet.md
@@ -11,11 +11,10 @@ assignees: ''
 
 **Attendance**
 
-- [ ] team member1
-- [ ] team member2
-- [ ] team member3
-- [ ] team member4
-- [ ] team member5
+- [ ] Emily Perica
+- [ ] Ian Algenio
+- [ ] Jackson Lippert
+- [ ] Mark Kogan
 
 **Agenda**
 

--- a/.github/ISSUE_TEMPLATE/ta_meet.md
+++ b/.github/ISSUE_TEMPLATE/ta_meet.md
@@ -13,11 +13,10 @@ assignees: ''
 
 **Attendance**
 
-- [ ] team member1
-- [ ] team member2
-- [ ] team member3
-- [ ] team member4
-- [ ] team member5
+- [ ] Emily Perica
+- [ ] Ian Algenio
+- [ ] Jackson Lippert
+- [ ] Mark Kogan
 
 **Questions to Ask**
 

--- a/.github/ISSUE_TEMPLATE/team_meet.md
+++ b/.github/ISSUE_TEMPLATE/team_meet.md
@@ -17,5 +17,14 @@ assignees: ''
 - [ ] Mark Kogan
 
 **Agenda**
+1. Discuss/review team member updates:
+  - Recent changes made.
+  - Problems encountered.
+  - Status of previous meeting action items.
 
+1. Go over new business.
+  - Discuss future deliverables/tasks to be done.
+  - Discuss individual and/or group next steps.
+  
+1. Assign action items.
 - 

--- a/.github/ISSUE_TEMPLATE/team_meet.md
+++ b/.github/ISSUE_TEMPLATE/team_meet.md
@@ -18,13 +18,12 @@ assignees: ''
 
 **Agenda**
 1. Discuss/review team member updates:
-  - Recent changes made.
-  - Problems encountered.
-  - Status of previous meeting action items.
+   - Recent changes made.
+   - Problems encountered.
+   - Status of previous meeting action items.
 
 1. Go over new business.
-  - Discuss future deliverables/tasks to be done.
-  - Discuss individual and/or group next steps.
+   - Discuss future deliverables/tasks to be done.
+   - Discuss individual and/or group next steps.
   
 1. Assign action items.
-- 

--- a/.github/ISSUE_TEMPLATE/team_meet.md
+++ b/.github/ISSUE_TEMPLATE/team_meet.md
@@ -11,11 +11,10 @@ assignees: ''
 
 **Attendance**
 
-- [ ] team member1
-- [ ] team member2
-- [ ] team member3
-- [ ] team member4
-- [ ] team member5
+- [ ] Emily Perica
+- [ ] Ian Algenio
+- [ ] Jackson Lippert
+- [ ] Mark Kogan
 
 **Agenda**
 


### PR DESCRIPTION
﻿## GitHub Issue

Issue #19

## Description

Replaced all generic team member names in issue templates, also added agenda items to team_meet.md since we agreed on the items in Issue #18. 

## How I tested

N/A
