### PR TITLE
Issue #32: Enforcing commit message convention

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,25 @@
+name: Commit Message Check
+
+on: [pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3.0.0
+
+      - name: Fetch all branches
+        run: |
+          git fetch --prune --unshallow
+
+      - name: Check Commit Messages
+        run: |
+          echo "Checking commit messages..."
+          # Get the latest commit messages only from the PR merge commit
+          commit_messages=$(git log origin/main..HEAD --pretty=format:%s)
+          echo "$commit_messages" | grep -E '^Issue #[0-9]+:' || {
+            echo "One or more commit messages do not follow the convention. Please use 'Issue #n:' format."
+            exit 1
+          }


### PR DESCRIPTION
﻿## GitHub Issue

Issue #28  

## Description

Enforcing commit message to follow convention by starting with Issue #n: where n is some GitHub issue number.

## How I tested

Making pull requests with  multiple different commit messages.
