### PR TITLE
Issue #227: Crude integration of element extraction, XML generation

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -3,14 +3,12 @@
 
 #include <string>
 
-using namespace std;
-
-struct Note {
-    string pitch; // Note pitch (e.g., "C")
+struct XMLNote {
+    std::string pitch; // Note pitch (e.g., "C")
     float alter = 0; // Chromatic alteration 
-    int octave = 4; // Octave
-    int duration = 0; // Duration in divisions
-    string type; // Note type (i.e. quarter, half, etc.)
+    int octave; // Octave
+    int duration; // Duration in divisions
+    std::string type; // Note type (i.e. quarter, half, etc.)
     bool isRest = false; // Rest note flag
 };
 

--- a/include/dsp.h
+++ b/include/dsp.h
@@ -5,9 +5,19 @@
 #include <vector>
 #include <sndfile.h>
 #include "detectNoteDuration.h"
+#include "common.h"
+#include "findKey.h"
 
 using namespace std;
 
-void dsp(char const* input_file);
+struct DSPResult {
+    vector<XMLNote> XMLNotes;
+    string timeSignature;
+    int keySignature;
+    int bpm;
+    int divisions;
+};
+
+DSPResult dsp(char const* input_file);
 
 #endif

--- a/include/generateMusicXML.h
+++ b/include/generateMusicXML.h
@@ -15,32 +15,33 @@
 using namespace std;
 using namespace MusicXML2;
 
-#define KEY_SIG 0 // C major, +ve for sharps, -ve for flats
-#define CLEF "G" // Clef in "G", "F", "C", "percussion", "TAB" or "none"
-#define CLEF_LINE 2 // Treble clef line
-#define TIME_SIG "4/4"
-#define BEATS_PER_DIV 4 // Beats per division
-
 class MusicXMLGenerator 
 {
 
 public:
-    // Note: some fof the below parameters are optional and can be set to null or nullptr while others cannot
+    // Note: some of the below parameters are optional and can be set to null or nullptr while others cannot
     // see lihbmusicxml.h
     MusicXMLGenerator(
-    const string& workNumber = "WORN_NUMBER",
-    const string& workTitle = "WORK_TITLE",
-    const string& movementNumber = "MVMT_NUMBER",
-    const string& movementTitle = "MVMNT_TITLE",
-    const string& creatorName = "CREATOR_NAME",
-    const string& creatorType = "CREATOR_TYPE",
-    const string& rightsString = "RIGHTS_STRING",
-    const string& rightsType = "RIGHTS_TYPE",
-    const string& encodingSoftware = "ScoreGen");
+        const string& workNumber = "WORN_NUMBER",
+        const string& workTitle = "WORK_TITLE",
+        const string& movementNumber = "MVMT_NUMBER",
+        const string& movementTitle = "MVMNT_TITLE",
+        const string& creatorName = "CREATOR_NAME",
+        const string& creatorType = "CREATOR_TYPE",
+        const string& rightsString = "RIGHTS_STRING",
+        const string& rightsType = "RIGHTS_TYPE",
+        const string& encodingSoftware = "ScoreGen");
 
     ~MusicXMLGenerator();
 
-    bool generate(const vector<Note>& noteSequence, const string& outputPath, int divisions = DIVISIONS);
+    bool generate(
+        const string& outputPath,
+        const vector<XMLNote>& noteSequence,
+        const string& clef,
+        const int& clefLine,
+        const string& timeSignature,
+        const int& keySignature,
+        int divisions);
 
 private:
     TFactory factory;
@@ -48,9 +49,14 @@ private:
         const string& partId = "P1", 
         const string& partName = "INSTRUMENT", 
         const string& partAbbrev = "INST_ABBREV");
-    TElement createPart(const vector<Note>& noteSequence, int divisions);
-    TElement createMeasure(const vector<Note>& measureNotes, int measureNumber, int divisions);
-    TElement createNoteElement(const Note& note, int divisions);
+
+    TElement createPart(const vector<XMLNote>& noteSequence,  const string& clef, 
+        const int& clefLine, const string& timeSignature, const int& keySignature, int divisions);
+
+    TElement createMeasure(const vector<XMLNote>& measureNotes, int measureNumber, const string& clef, 
+        const int& clefLine, const string& timeSignature, const int& keySignature, int divisions);
+
+    TElement createNoteElement(const XMLNote& note, int divisions);
 };
 
 #endif

--- a/src/ScoreGen.cpp
+++ b/src/ScoreGen.cpp
@@ -1,8 +1,26 @@
 #include <iostream>
 #include "dsp.h"
+#include "generateMusicXML.h"
 
-#define TEST_DATA "test/TestingDatasets/piano-samples/sample-scales/c-major-scale-on-treble-clef.wav"
+#define TEST_DATA "test/TestingDatasets/Computer-Generated-Samples/D4_to_E5_1_second_per_note.wav"
+
+#define DEFAULT_OUT "output.xml"
+#define KEY_SIG 0 // C major, +ve for sharps, -ve for flats
+#define CLEF "G" // Clef in "G", "F", "C", "percussion", "TAB" or "none"
+#define CLEF_LINE 2 // Treble clef line
+#define TIME_SIG "4/4"
+#define DIVISIONS 4 // Divisions per beat
 
 int main() {
-    dsp(TEST_DATA);
+    DSPResult res = dsp(TEST_DATA);
+    MusicXMLGenerator XMLgenerator;
+
+    // Defaults are being used for clef, key, time, and divisions, see generateMusicXML.h
+    bool succ = XMLgenerator.generate(DEFAULT_OUT, res.XMLNotes, CLEF, CLEF_LINE, TIME_SIG, res.keySignature, DIVISIONS);
+
+    if (succ) {
+        std::cout << "MusicXML file generated successfully." << std::endl;
+    } else {
+        std::cout << "Failed to generate MusicXML file." << std::endl;
+    }
 }

--- a/src/findKey.cpp
+++ b/src/findKey.cpp
@@ -24,10 +24,6 @@ float getCorrelation(float x_hat, float y_hat, std::vector<float> x, std::vector
 
 std::string findKey(std::vector<int> durations)
 {
-    // test_data values from above link
-    std::vector<int> test_data{432, 231, 0, 405, 12, 316, 4, 126, 612, 0, 191, 1};
-    durations = test_data;
-
     float minor_coeff;
     float major_coeff;
     std::pair<std::string, float> key("C", 0.0f);
@@ -42,11 +38,11 @@ std::string findKey(std::vector<int> durations)
     for (int i=0; i<12; i++) {
         std::vector<int> key_sig;
         if (i == 0) {
-            key_sig = test_data;
+            key_sig = durations;
         }
         else {
-            key_sig.assign(test_data.begin() + i, test_data.end());
-            key_sig.insert(key_sig.end(), test_data.begin(), test_data.begin() + i);
+            key_sig.assign(durations.begin() + i, durations.end());
+            key_sig.insert(key_sig.end(), durations.begin(), durations.begin() + i);
         }
 
         minor_coeff = getCorrelation(minor_avg, duration_avg, minor_prof, key_sig);


### PR DESCRIPTION
﻿## GitHub Issue

Issue #227

## Description

I considered restructuring for more separation of concerns and decoupling but ultimately decided it would just be faster to do it this way. The DSP converts the metadata to structs needed for XML,  then is put in DSPResult struct for XML generation. 

## How I tested
I included what I ran in the main file to test, as far as I can tell it's truthful to the audio, this was the output: 
[out.zip](https://github.com/user-attachments/files/18634515/out.zip)
