### PR TITLE
Issue #227: Fixing notes per measure calculations

### DIFF
--- a/src/ScoreGen.cpp
+++ b/src/ScoreGen.cpp
@@ -9,7 +9,7 @@
 #define CLEF "G" // Clef in "G", "F", "C", "percussion", "TAB" or "none"
 #define CLEF_LINE 2 // Treble clef line
 #define TIME_SIG "4/4"
-#define DIVISIONS 4 // Divisions per beat
+#define DIVISIONS 480 // Divisions per beat
 
 int main() {
     DSPResult res = dsp(TEST_DATA);

--- a/src/dsp.cpp
+++ b/src/dsp.cpp
@@ -31,7 +31,7 @@ XMLNote convertToXMLNote(const Note& note) {
 
     // Convert note duration in s to duration in divisions
     float noteDurationInSeconds = note.endTime - note.startTime;
-    xmlNote.duration = static_cast<int>(noteDurationInSeconds * (defaultBPM / 60.0) * PPQ);
+    xmlNote.duration = static_cast<int>(std::round((noteDurationInSeconds * (defaultBPM / 60.0) * PPQ) / PPQ) * PPQ);
 
     xmlNote.pitch = noteName;
     xmlNote.octave = octave;


### PR DESCRIPTION
﻿## GitHub Issue

Issue #227

## Description

Adjusted duration calculation in dsp note conversion to round to nearest duration in divisions. Changed value of DIVISIONS to properly calculate notes per measure in xml generation.

## How I tested

