### PR TITLE
Issue #184: Onset detection and peak picking algorithms

### DIFF
--- a/include/detectNoteDuration.h
+++ b/include/detectNoteDuration.h
@@ -25,6 +25,8 @@ struct Note {
 std::string getNoteName(double freq);
 std::string determineNoteType(float noteDuration, int bpm);
 std::vector<Note> detectNotes(const std::vector<float>& buf, int sample_rate, int channels);
+std::vector<std::vector<double>> preProcessing(double lambda, std::vector<std::vector<double>> spectrogram)
+std::vector<Note> onsetDetection(const std::vector<double>& buf, int sample_rate);
 
 class Filter {
     public:
@@ -40,6 +42,5 @@ class Filter {
     std::vector<double> frequencies(int bands, double fmin, double fmax);
     static std::vector<double> triang(int start, int mid, int stop, bool equal = false);
 };
-
 
 #endif // NOTE_DETECTION_H

--- a/include/determineBPM.h
+++ b/include/determineBPM.h
@@ -17,5 +17,5 @@
 #include <aubio/aubio.h>
 
 float calculateMedian(const std::vector<float>& values);
-float getBufferBPM(const std::vector<float>& buf, int sample_rate, const std::map<std::string, std::string>& params = {});
+float getBufferBPM(const std::vector<double>& buf, int sample_rate, const std::map<std::string, std::string>& params = {});
 #endif // DETERMINE_BPM_H

--- a/src/backend/determineBPM.cpp
+++ b/src/backend/determineBPM.cpp
@@ -35,7 +35,7 @@ float beatsToBPM(const std::vector<float>& beats) {
 }
 
 // Function to calculate beats per minute (BPM) from a loaded buffer
-float getBufferBPM(const std::vector<float>& buf, int sample_rate, const std::map<std::string, std::string>& params) {
+float getBufferBPM(const std::vector<double>& buf, int sample_rate, const std::map<std::string, std::string>& params) {
     // Default settings
     int win_s = WIN_S, hop_s = HOP_S;
 

--- a/src/backend/dsp.cpp
+++ b/src/backend/dsp.cpp
@@ -4,8 +4,8 @@
 #define SILENCE_LENGTH 512
 #define PPQ 480 // Pulses per quarter note, default for MusicXML
 
-std::vector<float> prependSilence(const std::vector<float>& buf, size_t silenceLength) {
-    std::vector<float> paddedBuffer(silenceLength, 0.0f); // Add silence
+std::vector<double> prependSilence(const std::vector<float>& buf, size_t silenceLength) {
+    std::vector<double> paddedBuffer(silenceLength, 0.0f); // Add silence
     paddedBuffer.insert(paddedBuffer.end(), buf.begin(), buf.end());
     return paddedBuffer;
 }
@@ -118,7 +118,8 @@ DSPResult dsp(const char* infilename) {
         buf = move(tempBuffer);
     }
 
-    std::vector<float> paddedBuf = prependSilence(buf, SILENCE_LENGTH);
+    std::vector<double> paddedBuf = prependSilence(buf, SILENCE_LENGTH);
+    //std::vector<Note> notes = onsetDetection(paddedBuf, sfinfo.samplerate);
 
     // Extract notes
     std::vector<Note> notes = detectNotes(paddedBuf, sfinfo.samplerate, sfinfo.channels);


### PR DESCRIPTION
﻿## GitHub Issue

Issue #184

## Description
Follow up to PR #256 - implementation of the modified spectral flux algorithm for onset detection, as well as the peak picking algorithm, both described in https://archives.ismir.net/ismir2012/paper/000049.pdf. Note that this method of onset detection doesn't work well for computer generated signals, which maintain a constant magnitude as opposed to a human-played note which will experience a spike at note onset.
<!-- provide a brief description of the changes made in this pull request -->

## How I tested

<!-- describe the steps used to test your changes -->
