### PR TITLE
Issue #299: Adding input modal for mxml params

### DIFF
--- a/ScoreGen.Tests/generateMusicXML.Test.cpp
+++ b/ScoreGen.Tests/generateMusicXML.Test.cpp
@@ -14,10 +14,7 @@ protected:
         "M001", 
         "Test Movement", 
         "GTest", 
-        "TestingSoftware", 
-        "rights", 
-        "rights type", 
-        "Testing"
+        "TestingSoftware"
     ) {}
 
     // Updated default parameters to match generate() logic
@@ -157,7 +154,6 @@ TEST_F(MusicXMLGeneratorTest, FullGeneration) {
         noteSequence, 
         "G", 
         2,
-        "4/4", 
         0,
         4
     ));
@@ -178,7 +174,6 @@ TEST_F(MusicXMLGeneratorTest, EmptySequenceGeneration) {
         emptySequence, 
         "G", 
         2, 
-        "4/4", 
         0, 
         4
     ));

--- a/include/generateMusicXML.h
+++ b/include/generateMusicXML.h
@@ -18,10 +18,9 @@ class MusicXMLGenerator {
             const std::string& movementNumber = "MVMT_NUMBER",
             const std::string& movementTitle = "MVMNT_TITLE",
             const std::string& creatorName = "CREATOR_NAME",
-            const std::string& creatorType = "CREATOR_TYPE",
-            const std::string& rightsString = "RIGHTS_STRING",
-            const std::string& rightsType = "RIGHTS_TYPE",
-            const std::string& encodingSoftware = "ScoreGen");
+            const std::string& instrument = "INSTRUMENT",
+            const std::string& timeSignature = "4/4"
+        );
     
         ~MusicXMLGenerator();
     
@@ -31,12 +30,13 @@ class MusicXMLGenerator {
             const std::vector<XMLNote>& noteSequence,
             const std::string& clef,
             const int& clefLine,
-            const std::string& timeSignature,
             const int& keySignature,
             int divisions);
     
     private:
         TFactory factory;
+        std::string instrument_;
+        std::string timeSignature_;
     
         // Create a score-part element for the part-list.
         TElement createScorePart(

--- a/src/backend/ScoreGen.cpp
+++ b/src/backend/ScoreGen.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
 #include <string>
+#include <sstream>
+#include <vector>
 #include "dsp.h"
 #include "generateMusicXML.h"
 #include "recordAudio.h"
@@ -12,15 +14,28 @@
 #define DEFAULT_TIME_SIG "4/4"
 #define DEFAULT_DIVISIONS 480
 
-void processAudio() {
+
+std::vector<std::string> splitString(const std::string& str, char delimiter) {
+    std::vector<std::string> tokens;
+    std::string token;
+    std::istringstream tokenStream(str);
+    while (std::getline(tokenStream, token, delimiter)) {
+        tokens.push_back(token);
+    }
+    return tokens;
+}
+
+void processAudio(const std::string& workTitle, const std::string& workNumber,
+    const std::string& movementNumber, const std::string& movementTitle,
+    const std::string& creatorName, const std::string& instrument, const std::string& timeSignature) {
+
     DSPResult res = dsp("temp.wav");
-    MusicXMLGenerator xmlGenerator;
+    MusicXMLGenerator xmlGenerator(workNumber, workNumber, movementNumber, movementTitle, creatorName, instrument, timeSignature);
     bool success = xmlGenerator.generate(
         DEFAULT_OUT, 
         res.XMLNotes, 
         DEFAULT_CLEF, 
         DEFAULT_CLEF_LINE, 
-        DEFAULT_TIME_SIG, 
         res.keySignature, 
         DEFAULT_DIVISIONS
     );
@@ -35,12 +50,29 @@ void processAudio() {
 }
 
 int main() {
-    std::string command;
-    while (std::getline(std::cin, command)) {
-        if (command == "processAudio") {
-            processAudio();
-        } else {
-            std::cerr << "Unknown command: " << command << std::endl;
+    std::string input;
+    while (std::getline(std::cin, input)) {
+        if (input.find("processAudio") == 0) {
+            std::vector<std::string> params = splitString(input, '|');
+
+            if (params.size() == 8) {
+                std::string command = params[0];
+                std::string workTitle = params[1];
+                std::string workNumber = params[2];
+                std::string movementNumber = params[3];
+                std::string movementTitle = params[4];
+                std::string creatorName = params[5];
+                std::string instrument = params[6];
+                std::string timeSignature = params[7];
+
+                processAudio(workTitle, workNumber, movementNumber, movementTitle, creatorName, instrument, timeSignature);
+            }
+            else {
+                std::cerr << "Invalid number of parameters. Expected 8 but got " << params.size() << "." << std::endl;
+            }
+        }
+        else {
+            std::cerr << "Unknown command: " << input << std::endl;
         }
     }
     return 0;

--- a/src/backend/generateMusicXML.cpp
+++ b/src/backend/generateMusicXML.cpp
@@ -35,16 +35,17 @@ MusicXMLGenerator::MusicXMLGenerator(
     const string& movementNumber,
     const string& movementTitle,
     const string& creatorName,
-    const string& creatorType,
-    const string& rightsString,
-    const string& rightsType,
-    const string& encodingSoftware)
+    const string& instrument,
+    const string& timeSignature)
+    :
+    instrument_(instrument),
+    timeSignature_(timeSignature)
 {
     factory = factoryOpen();
     factoryHeader(factory, workNumber.c_str(), workTitle.c_str(), movementNumber.c_str(), movementTitle.c_str());
-    factoryCreator(factory, creatorName.c_str(), creatorType.c_str());
-    factoryRights(factory, rightsString.c_str(), rightsType.c_str());
-    factoryEncoding(factory, encodingSoftware.c_str());
+    factoryCreator(factory, creatorName.c_str(), nullptr);
+    factoryRights(factory, nullptr, nullptr);
+    factoryEncoding(factory, "ScoreGen");
 }
 
 //------------------------------------------------------------------------------
@@ -63,16 +64,15 @@ bool MusicXMLGenerator::generate(const string& outputPath,
                                  const vector<XMLNote>& noteSequence,
                                  const string& clef,
                                  const int& clefLine,
-                                 const string& timeSignature,
                                  const int& keySignature,
                                  int divisions)
 {
     if (noteSequence.empty()) return false;
 
-    TElement scorePart = createScorePart("P1", "INSTRUMENT", "");
+    TElement scorePart = createScorePart("P1", instrument_, "");
     factoryAddPart(factory, scorePart);
 
-    TElement part = createPart(noteSequence, clef, clefLine, timeSignature, keySignature, divisions);
+    TElement part = createPart(noteSequence, clef, clefLine, timeSignature_, keySignature, divisions);
     factoryAddPart(factory, part);
 
     fstream outFile(outputPath, ios::out);

--- a/src/frontend/main.js
+++ b/src/frontend/main.js
@@ -75,13 +75,16 @@ app.whenReady().then(() => {
     });
   
     // 3) Handle "process-audio" via a Promise (so the renderer can await it)
-    ipcMain.handle('process-audio', async () => {
-        console.log('[Main] ipcMain.handle("process-audio") triggered');
-      
+    ipcMain.handle('process-audio', async (event, command) => {
+        console.log('[Main] ipcMain.handle("process-audio") triggered'); 
+        
         return new Promise((resolve, reject) => {
           if (!childProc || !childProc.stdin.writable) {
             return reject(new Error('C++ process is not available.'));
-          }
+            }
+
+          console.log(`[Main] Sending command to backend: ${command}`);
+
           let resolved = false;
       
           const timeout = setTimeout(() => {
@@ -111,7 +114,7 @@ app.whenReady().then(() => {
       
           // Attach the listener before sending the command
           childProc.stdout.on('data', onData);
-          childProc.stdin.write('processAudio\n');
+          childProc.stdin.write(command + '\n');
         });
     });
   

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -18,7 +18,7 @@ contextBridge.exposeInMainWorld('electron', {
 });
 
 contextBridge.exposeInMainWorld('api', {
-    processAudio: () => ipcRenderer.invoke('process-audio')
+    processAudio: (command) => ipcRenderer.invoke('process-audio', command)
   });
   
 contextBridge.exposeInMainWorld('nodeAPI', {

--- a/src/frontend/record.html
+++ b/src/frontend/record.html
@@ -43,91 +43,148 @@
   </style>
 </head>
 <body>
-  <!-- Custom Title Bar -->
-  <div class="title-bar">
-    <button id="home-nav-btn" class="btn-nav-logo" aria-label="Navigate to Home">
-      <img src="assets/scoregen.png" alt="Logo" class="title-bar-logo">
-    </button>
-    <div class="nav-buttons">
-      <button id="upload-nav-btn" class="btn-nav">Upload</button>
-      <button id="record-nav-btn" class="btn-nav">Record</button>
+    <!-- Custom Title Bar -->
+    <div class="title-bar">
+        <button id="home-nav-btn" class="btn-nav-logo" aria-label="Navigate to Home">
+            <img src="assets/scoregen.png" alt="Logo" class="title-bar-logo">
+        </button>
+        <div class="nav-buttons">
+            <button id="upload-nav-btn" class="btn-nav">Upload</button>
+            <button id="record-nav-btn" class="btn-nav">Record</button>
+        </div>
     </div>
-  </div>
 
-  <div class="app-container">   
-    <main>
-      <div class="device-selection">
-        <label for="input-device-select">Input Device:</label>
-        <select id="input-device-select"></select>
-      </div>
-      <div class="button-group">
-        <!-- Recording Controls -->
-        <div class="recording-controls">
-          <!-- (Optional: Add a display element for recording length if desired) -->
-          <div class="recording-timer">
-            <span id="recording-length">0:00</span>
-          </div>
-          <button id="start-recording" class="btn btn-record" aria-label="Start Recording">
-            <i class="fas fa-circle"></i>
-          </button>
-          <button id="pause-recording" class="btn btn-pause" aria-label="Pause Recording" disabled>
-            <i class="fas fa-pause"></i>
-          </button>
-          <button id="stop-recording" class="btn btn-stop" aria-label="Stop Recording" disabled>
-            <i class="fas fa-stop"></i>
-          </button>
-          <div class="upload-controls">
-            <button id="upload-file-button" class="btn btn-upload">
-              <i class="fas fa-upload"></i>
-            </button>
-            <input type="file" id="upload-file" accept=".wav" style="display:none;">
-          </div>
-          <button id="save-recording" class="btn btn-save" aria-label="Save Recording" disabled>
-            <i class="fas fa-save"></i>
-          </button>
-          <button id="export-musicxml" class="btn btn-export" aria-label="Export to MusicXML" disabled>
-            <i class="fas fa-file-export"></i>
-          </button>
-        </div>
-      </div>
-      
-      <!-- Frequency canvas (if needed for visualization) -->
-      <canvas id="frequencyCanvas" width="800" height="400"></canvas>
-      
-      <!-- Playback Section -->
-      <section id="playback-section">
-        <!-- The audio element will receive the recorded audio URL -->
-        <audio id="audio" src=""></audio>
-        <div class="audio-player">
-          <div class="controls">
-            <button id="prev-button" class="control-button" title="Previous">
-              <i class="fas fa-backward"></i>
-            </button>
-            <button id="play-pause-button" class="control-button" title="Play" disabled>
-              <i class="fas fa-play"></i>
-            </button>
-            <button id="next-button" class="control-button" title="Next">
-              <i class="fas fa-forward"></i>
-            </button>
-          </div>
-          <div class="progress-container">
-            <span id="current-time">0:00</span>
-            <input type="range" id="progress-bar" min="0" max="100" value="0" step="0.1">
-            <span id="total-duration">0:00</span>
-          </div>
-        </div>
-      </section>
-    </main>
-  </div>
+    <div class="app-container">
+        <main>
+            <div class="device-selection">
+                <label for="input-device-select">Input Device:</label>
+                <select id="input-device-select"></select>
+            </div>
+            <div class="button-group">
+                <!-- Recording Controls -->
+                <div class="recording-controls">
+                    <!-- (Optional: Add a display element for recording length if desired) -->
+                    <div class="recording-timer">
+                        <span id="recording-length">0:00</span>
+                    </div>
+                    <button id="start-recording" class="btn btn-record" aria-label="Start Recording">
+                        <i class="fas fa-circle"></i>
+                    </button>
+                    <button id="pause-recording" class="btn btn-pause" aria-label="Pause Recording" disabled>
+                        <i class="fas fa-pause"></i>
+                    </button>
+                    <button id="stop-recording" class="btn btn-stop" aria-label="Stop Recording" disabled>
+                        <i class="fas fa-stop"></i>
+                    </button>
+                    <div class="upload-controls">
+                        <button id="upload-file-button" class="btn btn-upload">
+                            <i class="fas fa-upload"></i>
+                        </button>
+                        <input type="file" id="upload-file" accept=".wav" style="display:none;">
+                    </div>
+                    <button id="save-recording" class="btn btn-save" aria-label="Save Recording" disabled>
+                        <i class="fas fa-save"></i>
+                    </button>
+                    <button id="export-musicxml" class="btn btn-export" aria-label="Export to MusicXML" disabled>
+                        <i class="fas fa-file-export"></i>
+                    </button>
+                </div>
+            </div>
 
-  <!-- Spinner overlay -->
-  <div id="spinnerOverlay">
-    <div class="spinner"></div>
-  </div>
-  
-  <!-- Scripts -->
-  <script src="record.js"></script>
-  <script src="nav.js"></script>
-  <script src="frequency.js"></script>
+            <!-- Frequency canvas (if needed for visualization) -->
+            <canvas id="frequencyCanvas" width="800" height="400"></canvas>
+
+            <!-- Playback Section -->
+            <section id="playback-section">
+                <!-- The audio element will receive the recorded audio URL -->
+                <audio id="audio" src=""></audio>
+                <div class="audio-player">
+                    <div class="controls">
+                        <button id="prev-button" class="control-button" title="Previous">
+                            <i class="fas fa-backward"></i>
+                        </button>
+                        <button id="play-pause-button" class="control-button" title="Play" disabled>
+                            <i class="fas fa-play"></i>
+                        </button>
+                        <button id="next-button" class="control-button" title="Next">
+                            <i class="fas fa-forward"></i>
+                        </button>
+                    </div>
+                    <div class="progress-container">
+                        <span id="current-time">0:00</span>
+                        <input type="range" id="progress-bar" min="0" max="100" value="0" step="0.1">
+                        <span id="total-duration">0:00</span>
+                    </div>
+                </div>
+            </section>
+        </main>
+    </div>
+
+    <!-- Spinner overlay -->
+    <div id="spinnerOverlay">
+        <div class="spinner"></div>
+    </div>
+
+    <!-- Scripts -->
+    <script src="record.js"></script>
+    <script src="nav.js"></script>
+    <script src="frequency.js"></script>
+
+    <div class="modal" id="musicxmlModal">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h2 id="musicxmlModalLabel">Configure Score Sheet</h2>
+            <button id="modalClose" class="modal-close-btn">&times;</button>
+          </div>
+          <form id="musicxmlForm">
+            <div class="modal-body">
+            <!-- Creator Information -->
+            <fieldset class="modal-fieldset">
+                <legend>Creator Information</legend>
+                <div class="form-group">
+                <label for="creatorName">Creator Name</label>
+                <input type="text" id="creatorName" name="creatorName" placeholder="Enter your name" required>
+                </div>
+            </fieldset>
+            <!-- Score Details -->
+            <fieldset class="modal-fieldset">
+                <legend>Score Details</legend>
+                <div class="form-group">
+                <label for="instrumentInput">Instrument</label>
+                <input type="text" id="instrumentInput" name="instrument" placeholder="Enter instrument name (e.g., Piano, Violin)" required>
+                </div>
+                <div class="form-group">
+                <label for="timeSignatureInput">Time Signature</label>
+                <input type="text" id="timeSignatureInput" name="timeSignature" placeholder="Enter a time signature (e.g., 4/4, 3/4)" required pattern="^\d+\/\d+$" title="Please enter a valid time signature (e.g., 4/4)">
+                </div>
+            </fieldset>
+             <!-- Score Metadata -->
+            <fieldset class="modal-fieldset">
+                <legend>Score Metadata</legend>
+                <div class="form-group">
+                <label for="workNumber">Work Number</label>
+                <input type="text" id="workNumber" name="workNumber" placeholder="Enter work number" required>
+                </div>
+                <div class="form-group">
+                <label for="workTitle">Work Title</label>
+                <input type="text" id="workTitle" name="workTitle" placeholder="Enter work title" required>
+                </div>
+                <div class="form-group">
+                <label for="movementNumber">Movement Number</label>
+                <input type="text" id="movementNumber" name="movementNumber" placeholder="Enter movement number" required>
+                </div>
+                <div class="form-group">
+                <label for="movementTitle">Movement Title</label>
+                <input type="text" id="movementTitle" name="movementTitle" placeholder="Enter movement title" required>
+                </div>
+            </fieldset>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-cancel" id="modalCancel">Cancel</button>
+              <button type="submit" class="btn btn-enter">Generate Score Sheet</button>
+            </div>
+          </form>
+        </div>
+      </div>      
 </body>
 </html>

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -287,6 +287,16 @@ body {
     transform: translateY(0);
 }
 
+.btn-cancel {
+    background-color: lightgrey;
+    color: white;
+}
+
+.btn-cancel:hover {
+    background-color: #aaa;
+    transform: translateY(-2px);
+}
+
 #record-btn {
     background-color: #dc3545;
 }
@@ -639,4 +649,121 @@ body {
         padding: 4px 8px;
         font-size: 14px;
     }
+}
+
+/* Modal Container */
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1000; 
+    top: 0;
+    left: 0; 
+    width: 100%;
+    height: 100%;
+    overflow-y: auto;
+    background-color: rgba(0, 0, 0, 0.6);
+    padding: 20px;
+}
+
+/* Modal Content Box */
+.modal-content {
+    background-color: #f4f4f4;
+    border-radius: 8px;
+    max-width: 600px;
+    margin: 50px auto;
+    padding: 0 20px 20px 20px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+}
+
+/* Modal Header */
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid #ddd;
+    padding: 10px 20px;
+    background-color: #2f3241;
+    margin: 0 -20px;
+    border-top-left-radius: 8px;
+    border-top-right-radius: 8px; 
+}
+
+.modal-header h2 {
+    margin: 0;
+    font-size: 24px; 
+    color: #ddd;
+}
+
+/* Modal Close Button */
+.modal-close-btn {
+    background: none;
+    border: none;
+    font-size: 28px;
+    cursor: pointer;
+    color: #f0f0f0;
+    transition: color 0.3s;
+}
+
+.modal-close-btn:hover {
+    color: #aaa;
+}
+
+/* Modal Body */
+.modal-body {
+    padding: 0px 0 20px 0;
+}
+
+/* Modal Footer */
+.modal-footer {
+    display: flex;
+    gap: 10px;
+    justify-content: flex-end;
+    padding-top: 10px;
+}
+
+/* Fieldsets */
+.modal-fieldset {
+    background-color: #ffffff; 
+    border: none; 
+    border-radius: 8px; 
+    padding: 15px 15px 15px 15px; 
+    margin-top: 45px; 
+    margin-bottom: 30px; 
+    overflow: visible; 
+    position: relative;
+}
+
+.modal-fieldset legend {
+    display: block;
+    font-size: 18px;
+    color: #2f3241;
+    font-weight: bold;
+    position: absolute;
+    top: -25px;
+    left: 0;
+    background-color: transparent;
+    padding: 0;
+    margin: 0;
+}
+
+/* Fieldset Form Groups */
+.modal-fieldset .form-group {
+    margin-bottom: 15px;
+}
+
+.modal-fieldset .form-group label {
+    display: block;
+    font-size: 16px;
+    color: #2f3241;
+    margin-bottom: 5px;
+}
+
+/* Input Fields */
+.modal-fieldset .form-group input {
+    width: 100%;
+    padding: 8px;
+    border: 1px solid #2f3241;
+    border-radius: 4px;
+    background-color: #ffffff;
+    color: #333;
 }


### PR DESCRIPTION
﻿## GitHub Issue

Issue #299

## Description

Command thats passed from frontend contains all the params needed by the xml generator (including the time signature and instrument). The export button now just triggers the modal, then modal submit triggers the generation. Made the style match the rest of the app.

## How I tested

I tested on mac b/c I forgot to switch to windows, but none of these changes are OS dependent anyways. The generated xmls show the input to the forms correctly.
